### PR TITLE
Upgrade to elasticsearch 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/ccowan/bunyan-elasticsearch",
   "dependencies": {
     "moment": "~2.5.1",
-    "elasticsearch": "~1.5.8"
+    "elasticsearch": "~4.1.0"
   },
   "devDependencies": {
     "mocha": "~1.17.1"


### PR DESCRIPTION
To work with elasticsearch 1.5.2, a newer elasticsearch module is needed. I have tested with 4.1.0 and it works fine, at least for my simple use-case.