### PR TITLE
Emit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install bunyan-elasticsearch
 
 ## Logstash Template
 
-By default Logstash will create a dynamic template that will take care of crating `.raw` fields for your data. In order to replicate this behaivor you will need to create the dynamic template manually. You will need to [download template.json](https://raw.github.com/ccowan/bunyan-elasticsearch/master/template.json) and run the following command from the same directory as that file:
+By default Logstash will create a dynamic template that will take care of crating `.raw` fields for your data. In order to replicate this behavior you will need to create the dynamic template manually. You will need to [download template.json](https://raw.github.com/ccowan/bunyan-elasticsearch/master/template.json) and run the following command from the same directory as that file:
 
 ```
 curl -XPUT localhost:9200/_template/logstash -d @template.json
@@ -25,7 +25,10 @@ var Elasticsearch = require('bunyan-elasticsearch');
 var esStream = new Elasticsearch({
   indexPattern: '[logstash-]YYYY.MM.DD',
   type: 'logs',
-  host: 'localhost:9200' 
+  host: 'localhost:9200'
+});
+esStream.on('error', function (err) {
+  console.log('Elasticsearch Stream Error:', err.stack);
 });
 
 var logger = bunyan.createLogger({
@@ -40,3 +43,11 @@ var logger = bunyan.createLogger({
 logger.info('Starting application on port %d', app.get('port'));
 ```
 
+## Options
+
+* `client`: Elasticsearch client. Defaults to new client created with current set of options as an argument
+* `type` {string|function}: Elasticsearch `type` field. Default: `'logs'`
+* `indexPattern` {string}: Used to generate index if `index` option not set. Default: `'[logstash-]YYYY.MM.DD'`
+* `index` {string|function}: Elasticsearch index. Defaults to index generated using index pattern
+
+Options `type` and `index` can be either a string or function. For these options, when the option is set to a function, the function is passed the log entry object as an argument

--- a/index.js
+++ b/index.js
@@ -42,36 +42,33 @@ ElasticsearchStream.prototype._write = function (entry, encoding, callback) {
   var type = this._type;
 
   var d = domain.create();
-  d.on('error', function (err) { 
-    console.log("Elasticsearch Error", err.stack);
-  });
-  d.run(function () {
-    entry = JSON.parse(entry.toString('utf8'));
-    var env = process.env.NODE_ENV || 'development';
+  entry = JSON.parse(entry.toString('utf8'));
+  var env = process.env.NODE_ENV || 'development';
 
-    // Reassign these fields so them match what the default Kibana dashboard 
-    // expects to see.
-    entry['@timestamp'] = entry.time;
-    entry.level = levels[entry.level];
-    entry.message = entry.msg;
+  // Reassign these fields so them match what the default Kibana dashboard 
+  // expects to see.
+  entry['@timestamp'] = entry.time;
+  entry.level = levels[entry.level];
+  entry.message = entry.msg;
 
-    // remove duplicate fields
-    delete entry.time;
-    delete entry.msg;
+  // remove duplicate fields
+  delete entry.time;
+  delete entry.msg;
 
-    var datestamp = moment(entry.timestamp).format('YYYY.MM.DD');
+  var datestamp = moment(entry.timestamp).format('YYYY.MM.DD');
 
-    var options = {
-      index: callOrString(index, entry),
-      type: callOrString(type, entry),
-      body: entry
-    };
+  var options = {
+    index: callOrString(index, entry),
+    type: callOrString(type, entry),
+    body: entry
+  };
 
-    client.create(options, function (err, resp) {
-      if (err) console.log('Elasticsearch Stream Error:', err.stack);
-      callback();
-    });
-
+  var self = this;
+  client.create(options, function (err, resp) {
+    if (err) {
+      self.emit('error', err);
+    }
+    callback();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-elasticsearch",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "A Bunyan stream for sending log data to Elasticsearch",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR moves the responsibility for error handling to the consumer of the stream, so that errors can be handled in a manner more consistent with other stream types. It is technically a breaking change, as it requires the `esStream.onError` handler to be defined in order to suppress errors to simple console log entries  (see updated example), but allows greater flexibility with error handling, and also makes bunyan's `reemitErrorEvents` option useful for those who need it