### PR TITLE
Update to work with Elasticsearch 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ ElasticsearchStream.prototype._write = function (entry, encoding, callback) {
   };
 
   var self = this;
-  client.create(options, function (err, resp) {
+  client.index(options, function (err, resp) {
     if (err) {
       self.emit('error', err);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-elasticsearch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Bunyan stream for sending log data to Elasticsearch",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In ES 5, calls to create no longer generate an id, instead it must be explicitly set. (See https://github.com/elastic/elasticsearch-js/issues/453) So I've updated to use index instead (which still auto-generates the id).
