### PR TITLE
better compatibility for es 5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ ElasticsearchStream.prototype._write = function (entry, encoding, callback) {
   };
 
   var self = this;
-  client.create(options, function (err, resp) {
+  client.index(options, function (err, resp) {
     if (err) {
       self.emit('error', err);
     }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/ccowan/bunyan-elasticsearch",
   "dependencies": {
-    "moment": "^2.11.1",
-    "elasticsearch": "^10.1.2"
+    "moment": "^2.15.2",
+    "elasticsearch": "^12.0.1"
   },
   "devDependencies": {
     "mocha": "^2.3.4"


### PR DESCRIPTION
Updated to ES5.0.0 and logging broke, so I made the following change.

bump dependency versions and switched from client.create to client.index (see: https://github.com/elastic/elasticsearch-js/issues/453)