### PR TITLE
Adds a pipeline options for indexing

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function ElasticsearchStream (options) {
   this._type = options.type || 'logs';
   var indexPattern = options.indexPattern || '[logstash-]YYYY.MM.DD';
   this._index = options.index || generateIndexName.bind(null, indexPattern);
+  this._pipeline = options.pipeline || null;
   Writable.call(this, options);
 }
 
@@ -54,10 +55,12 @@ ElasticsearchStream.prototype._write = function (entry, encoding, callback) {
 
   var datestamp = moment(entry.timestamp).format('YYYY.MM.DD');
 
+  console.log('pipeline', this._pipeline);
   var options = {
     index: callOrString(index, entry),
     type: callOrString(type, entry),
-    body: entry
+    body: entry,
+    pipeline: this._pipeline
   };
 
   var self = this;

--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ ElasticsearchStream.prototype._write = function (entry, encoding, callback) {
 
   var datestamp = moment(entry.timestamp).format('YYYY.MM.DD');
 
-  console.log('pipeline', this._pipeline);
   var options = {
     index: callOrString(index, entry),
     type: callOrString(type, entry),


### PR DESCRIPTION
Adds the possibility to use a pipeline for indexing as for https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-index